### PR TITLE
Registry fixes

### DIFF
--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -98,7 +98,7 @@ export function createPluginRegistry(plugins: DatapromptPlugin[] = []) {
 
   const hasOwnFirestore = pluginsToRegister.some(plugin => plugin.name === 'firestore');
   const hasOwnFetch = pluginsToRegister.some(plugin => plugin.name === 'fetch');
-  const hasOwnScheduler = pluginsToRegister.some(plugin => plugin.name === 'scheduler');
+  const hasOwnScheduler = pluginsToRegister.some(plugin => plugin.name === 'schedule');
   if (!hasOwnFirestore) {
   }
   if (!hasOwnFetch) {

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -100,13 +100,13 @@ export function createPluginRegistry(plugins: DatapromptPlugin[] = []) {
   const hasOwnFetch = pluginsToRegister.some(plugin => plugin.name === 'fetch');
   const hasOwnScheduler = pluginsToRegister.some(plugin => plugin.name === 'schedule');
   if (!hasOwnFirestore) {
+    pluginsToRegister.push(firestorePlugin());
   }
   if (!hasOwnFetch) {
     pluginsToRegister.push(fetchPlugin());
   }
   if (!hasOwnScheduler) {
     pluginsToRegister.push(schedulerPlugin());
-    pluginsToRegister.push(firestorePlugin());
   }
   registry.registerMany(pluginsToRegister);
   return registry;


### PR DESCRIPTION
- Move Firestore plugin registration to its own spot
- `scheduler` --> `schedule` to match the [plugin name](https://github.com/davideast/dataprompt/blob/22ef7c4e6c9080712c9cdb7f72c83de25272823e/src/plugins/schedule/index.ts#L97)